### PR TITLE
Adds support for embedded behavioral questionnaire

### DIFF
--- a/src/iframe-navigation-utils.ts
+++ b/src/iframe-navigation-utils.ts
@@ -4,15 +4,16 @@
 export const IFRAME_DOMAIN = '__YS_IFRAME_DOMAIN__';
 
 const IFramePageRoutes = {
-    'report-builder': '/ui/embed/reports/'
+    'report-builder': '/ui/embed/reports/',
+    'behavioral-questionnaire': '/questionnaire/intro/',
 };
 export type IFramePageKey = keyof typeof IFramePageRoutes;
 
-export const getUrlForIFramePage = (pageKey: IFramePageKey) => {
+export const getUrlForIFramePage = (pageKey: IFramePageKey, slug: string = '') => {
     const route = IFramePageRoutes[pageKey];
     if (!route) {
         throw new Error(`Invalid page key: ${pageKey}`);
     }
-    return IFRAME_DOMAIN + route + '?is_embed=1';
+    return IFRAME_DOMAIN + route + (slug ? `${slug}/` : '') + '?is_embed=1';
 };
 

--- a/src/your-stake-embed.ts
+++ b/src/your-stake-embed.ts
@@ -3,6 +3,7 @@ import { IFRAME_DOMAIN, getUrlForIFramePage, IFramePageKey } from "./iframe-navi
 interface YSEmbedConstructorArgs {
     targetElementIdentifier: string
     initialPage: IFramePageKey
+    slug: string
     width: string
     height: string
     clientId: string
@@ -23,6 +24,7 @@ class YourStakeEmbed {
     constructor({
         targetElementIdentifier,
         initialPage='report-builder',
+        slug='', // Will be appended to the end of the url
         width,
         height,
         clientId,
@@ -37,7 +39,7 @@ class YourStakeEmbed {
         this.iframeElement = document.createElement('iframe');
         this.iframeElement.id = 'yourstake-embedded-iframe';
         this.resizeIframe(width, height);
-        this.setIframePage(this.currentPage);
+        this.setIframePage(this.currentPage, slug);
         this.iframeElement.allow = `clipboard-write ${this.iframeDomain}`;
         this.iframeElement.onload = () => {
             this.sendPostMessageToIFrame('auth_data', {
@@ -62,10 +64,10 @@ class YourStakeEmbed {
         this.iframeElement.style.height = height;
     }
 
-    setIframePage(pageKey: IFramePageKey) {
+    setIframePage(pageKey: IFramePageKey, slug: string = '') {
         this.currentPage = pageKey;
         // TODO check that the specified page is a valid page which the user is authorized to load
-        this.iframeElement.src = getUrlForIFramePage(this.currentPage);
+        this.iframeElement.src = getUrlForIFramePage(this.currentPage, slug);
     }
 
     sendPostMessageToIFrame(messageType: PostMessageType, messageData: Object) {


### PR DESCRIPTION
This adds support for embedding the behavioral questionnaire.
- Adds the url to `IFramePageRoutes`
- Adds a new `slug` arg that the client provides, which gets appended to the url. This is needed because the last part of the questionnaire url is a slug that can be customized by the client.